### PR TITLE
Close the Zenoh session after destroying the last node

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -24,6 +24,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -51,6 +52,12 @@ public:
 
   // An owned session.
   z_owned_session_t session;
+
+  // This is a temporary workaround for the unsoundness of rmw_shutdown
+  // reported in https://github.com/ros2/rmw_zenoh/issues/170.
+  // We keep track of all the nodes created in this session and only close
+  // the Zenoh session once the last node is destroyed.
+  std::unordered_set<const rmw_node_t *> session_nodes_;
 
   // An optional SHM provider that is initialized of SHM is enabled in the
   // zenoh session config.

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -413,11 +413,6 @@ rmw_shutdown(rmw_context_t * context)
   if (context->impl->shm_provider.has_value()) {
     z_drop(z_move(context->impl->shm_provider.value()));
   }
-  // Close the zenoh session
-  if (z_close(z_move(context->impl->session), NULL) != Z_OK) {
-    RMW_SET_ERROR_MSG("Error while closing zenoh session");
-    return RMW_RET_ERROR;
-  }
 
   context->impl->is_shutdown = true;
 


### PR DESCRIPTION
With this change I can get the failing test [here](https://github.com/ros2/rmw_zenoh/pull/276#pullrequestreview-2300681922) to pass. Didn't bother with thread safety here since that is the focus of other PRs in upstream rmw_zenoh. 