### PR TITLE
Change liveliness tokens logs from warn to debug level

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -595,8 +595,9 @@ void GraphCache::parse_del(
       return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
     });
   if (node_it == range.second) {
-    // Node does not exist.
-    RMW_ZENOH_LOG_WARN_NAMED(
+    // Node does not exist or its liveliness token has been unregistered before one of its pubs/subs/service liveliness token.
+    // This could happen since Zenoh doesn't guarantee any order for unregistration events if the remote Node closed abruptly or was disconnected.
+    RMW_ZENOH_LOG_DEBUG_NAMED(
       "rmw_zenoh_cpp",
       "Received liveliness token to remove unknown node /%s from the graph. Ignoring...",
       entity->node_name().c_str()
@@ -606,16 +607,16 @@ void GraphCache::parse_del(
 
   if (entity->type() == EntityType::Node) {
     // Node
-    // The liveliness tokens to remove pub/subs should be received before the one to remove a node
-    // given the reliability QoS for liveliness subs. However, if we find any pubs/subs present in
-    // the node below, we should update the count in graph_topics_.
+    // In case the remote Node closed abruptly or was disconnected, Zenoh could deliver the liveliness tokens unregistration events
+    // in any order. If the event for Node unregistration comes before the unregistration of its pubs/subs/services,
+    // we should update the count in graph_topics_ and graph_services_.
     const GraphNodePtr graph_node = node_it->second;
     if (!graph_node->pubs_.empty() ||
       !graph_node->subs_.empty() ||
       !graph_node->clients_.empty() ||
       !graph_node->services_.empty())
     {
-      RMW_ZENOH_LOG_WARN_NAMED(
+      RMW_ZENOH_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp",
         "Received liveliness token to remove node /%s from the graph before all pub/subs/"
         "clients/services for this node have been removed. Removing all entities first...",

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -595,8 +595,9 @@ void GraphCache::parse_del(
       return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
     });
   if (node_it == range.second) {
-    // Node does not exist or its liveliness token has been unregistered before one of its pubs/subs/service liveliness token.
-    // This could happen since Zenoh doesn't guarantee any order for unregistration events if the remote Node closed abruptly or was disconnected.
+    // Node does not exist or its liveliness token has been unregistered before one of its
+    // pubs/subs/service liveliness token. This could happen since Zenoh doesn't guarantee
+    // any order for unregistration events if the remote Node closed abruptly or was disconnected.
     RMW_ZENOH_LOG_DEBUG_NAMED(
       "rmw_zenoh_cpp",
       "Received liveliness token to remove unknown node /%s from the graph. Ignoring...",
@@ -607,9 +608,10 @@ void GraphCache::parse_del(
 
   if (entity->type() == EntityType::Node) {
     // Node
-    // In case the remote Node closed abruptly or was disconnected, Zenoh could deliver the liveliness tokens unregistration events
-    // in any order. If the event for Node unregistration comes before the unregistration of its pubs/subs/services,
-    // we should update the count in graph_topics_ and graph_services_.
+    // In case the remote Node closed abruptly or was disconnected, Zenoh could deliver the
+    // liveliness tokens unregistration events in any order.
+    // If the event for Node unregistration comes before the unregistration of its
+    // pubs/subs/services, we should update the count in graph_topics_ and graph_services_.
     const GraphNodePtr graph_node = node_it->second;
     if (!graph_node->pubs_.empty() ||
       !graph_node->subs_.empty() ||


### PR DESCRIPTION
As agreed [here](https://github.com/ZettaScaleLabs/rmw_zenoh/pull/21#issuecomment-2364018388) change the log levels of warnings about "out-of-order" unregistration of liveliness tokens from `warn` to `debug`.

The reason is that in case a remote Node is disconnected or if it shuts down abruptly (calling `rmw_shutdown` and thus closing the Zenoh session before deleting its pubs/subs/services) Zenoh will locally deliver the events of liveliness tokens unregistrations in an arbitrary order. Thus it's likely that the unregistration of Node will be notified before the unregistration of its pubs/subs/services.