### PR TITLE
Fix unset request header writer GUID

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1874,6 +1874,8 @@ rmw_take_response(
     return RMW_RET_ERROR;
   }
 
+  memcpy(request_header->request_id.writer_guid, attachment.source_gid, RMW_GID_STORAGE_SIZE);
+
   request_header->source_timestamp = attachment.source_timestamp;
   if (request_header->source_timestamp < 0) {
     RMW_SET_ERROR_MSG("Failed to get source_timestamp from client call attachment");
@@ -2337,7 +2339,7 @@ rmw_take_request(
     return RMW_RET_ERROR;
   }
 
-  std::memcpy(request_header->request_id.writer_guid, attachment.source_gid, RMW_GID_STORAGE_SIZE);
+  memcpy(request_header->request_id.writer_guid, attachment.source_gid, RMW_GID_STORAGE_SIZE);
 
   request_header->source_timestamp = attachment.source_timestamp;
   if (request_header->source_timestamp < 0) {

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2337,6 +2337,8 @@ rmw_take_request(
     return RMW_RET_ERROR;
   }
 
+  std::memcpy(request_header->request_id.writer_guid, attachment.source_gid, RMW_GID_STORAGE_SIZE);
+
   request_header->source_timestamp = attachment.source_timestamp;
   if (request_header->source_timestamp < 0) {
     RMW_SET_ERROR_MSG("Failed to get source_timestamp from client call attachment");


### PR DESCRIPTION
The `gtest_multithreaded__rmw_zenoh_cpp` test of package `test_rclcpp` is quite flaky in the `ZettaScaleLabs:dev/1.0.0` branch. On around 1/10 runs I get:

```text
executor taking a service server request from service '/multi_consumer_clients' unexpectedly failed: 
duplicate sequence number in the map, 
at /tests/workspace/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_zenoh.cpp:2457, 
at ./src/rcl/service.c:343
```

If I add a hacky log statement right before the call to `add_to_query_map`:

```cpp
RMW_ZENOH_LOG_ERROR_NAMED("rmw_zenoh_cpp", "received query: gid=%zu, sn=%zu, thread_id=%zu", 
  (size_t*) request_header->request_id.writer_guid,
  request_header->request_id.sequence_number,
  std::this_thread::get_id());
```

I get queries with the same `writer_guid` and `sequence_number`:

```text
38: [ERROR] [1729779404.278215962] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779405.279791879] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779406.280309755] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779407.286302714] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779408.287449964] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779409.291142881] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779410.294799507] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779411.299335466] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779412.300401299] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779413.302097967] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779414.308076925] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779415.314352509] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779416.319158093] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779417.320878469] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779418.322744052] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
38: [ERROR] [1729779419.325122886] [rmw_zenoh_cpp]: received query: gid=281474046962464, sn=1, thread_id=281473285787680
```

Looking at the query attachment at the Zenoh level, I realized that the GUID is correctly propagated, but simply not set in `rmw_take_request`.