### PR TITLE
Enable CongestionControl::Block if QoS is reliable.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -147,6 +147,11 @@ std::shared_ptr<PublisherData> PublisherData::make(
 
   if (adapted_qos_profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
     opts.reliability = Z_RELIABILITY_RELIABLE;
+    // Note: Unlike DDS which blocks the Publisher only if QoS is RELIABLE + KEEP_ALL,
+    // we configure Zenoh to block for any RELIABLE Publisher.
+    // The reason being that over congested networks (where Zenoh is often used) the default
+    // behaviour would often lead to message losses, which could be problematic in the
+    // case of a "latched topic" (RELIABLE, TRANSIENT_LOCAL, KEEP_LAST(1), only 1 publication)
     opts.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
   }
   z_owned_publisher_t pub;

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -147,10 +147,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
 
   if (adapted_qos_profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
     opts.reliability = Z_RELIABILITY_RELIABLE;
-
-    if (adapted_qos_profile.history == RMW_QOS_POLICY_HISTORY_KEEP_ALL) {
-      opts.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
-    }
+    opts.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
   }
   z_owned_publisher_t pub;
   // TODO(clalancette): What happens if the key name is a valid but empty string?

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
@@ -34,7 +34,10 @@ void create_map_and_set_sequence_num(
 }
 
 ///=============================================================================
-ZenohQuery::ZenohQuery(const z_loaned_query_t * query, std::chrono::nanoseconds::rep received_timestamp) {
+ZenohQuery::ZenohQuery(
+  const z_loaned_query_t * query,
+  std::chrono::nanoseconds::rep received_timestamp)
+{
   z_query_clone(&query_, query);
   received_timestamp_ = received_timestamp;
 }


### PR DESCRIPTION
With DDS the only combination of QoS which makes a Publisher to block the publications in case of network congestion is with Reliability=RELIABLE and History=KEEP_ALL.
In order to closely mimic this behaviour `rmw_zenoh` is setting `Z_CONGESTION_CONTROL_BLOCK` only for this combinaison of QoS.

However, in case of a Publisher for a "latched topic", it will use such combination of QoS:
Reliability=RELIABLE, History=KEEP_LAST(1) and Durability=TRANSIENT_LOCAL.
This leads `rmw_zenoh` to set `Z_CONGESTION_CONTROL_DROP` for the Publisher. And in case of very congested network the single publication might be dropped. That's what happens in the case discussed here:
https://github.com/ZettaScaleLabs/rmw_zenoh/issues/38#issuecomment-2484892922

This PR solves this problem setting `Z_CONGESTION_CONTROL_BLOCK` for any Publisher with QoS Reliability=RELIABLE, whatever the other QoS are.
