### PR TITLE
Fix `z_view_string_t` to `std::string` conversion

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -46,8 +46,9 @@ void service_data_handler(z_loaned_query_t * query, void * data)
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Unable to obtain ServiceData from data for "
-      "service for %s",
-      z_loan(keystr)
+      "service for %.*s",
+      static_cast<int>(z_string_len(z_loan(keystr))),
+      z_string_data(z_loan(keystr))
     );
     return;
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -65,12 +65,14 @@ void sub_data_handler(z_loaned_sample_t * sample, void * data)
   z_owned_slice_t slice;
   z_bytes_to_slice(payload, &slice);
 
+  std::string topic_name(z_string_data(z_loan(keystr)), z_string_len(z_loan(keystr)));
+
   sub_data->add_new_message(
     std::make_unique<SubscriptionData::Message>(
       slice,
       z_timestamp_ntp64_time(z_sample_timestamp(sample)),
       std::move(attachment)),
-    z_string_data(z_loan(keystr)));
+    &topic_name);
 }
 }  // namespace
 

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
@@ -34,7 +34,10 @@ void create_map_and_set_sequence_num(
 }
 
 ///=============================================================================
-ZenohQuery::ZenohQuery(const z_loaned_query_t * query, std::chrono::nanoseconds::rep received_timestamp) {
+ZenohQuery::ZenohQuery(
+  const z_loaned_query_t * query,
+  std::chrono::nanoseconds::rep received_timestamp)
+{
   z_query_clone(&query_, query);
   received_timestamp_ = received_timestamp;
 }


### PR DESCRIPTION
Using AddressSanitizer, I found instances where a `z_view_string_t` was used to construct an `std::string` as if it was null-terminated, leading to `rmw_zenoh` reading garbage bytes.